### PR TITLE
Fixed MessageQueue import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import MessageQueue from 'react-native/Libraries/Utilities/MessageQueue'
+import MessageQueue from 'react-native/Libraries/BatchedBridge/MessageQueue'
 import Stream from './stream'
 import Log from './log'
 


### PR DESCRIPTION
This PR fixes `MessageQueue` import, since it was moved in RN 0.37